### PR TITLE
fix: réparations suite au changement de split_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Imports:
     assertthat,
     dplyr,
     fte,
-    here,
     jsonlite,
     logger,
     lubridate,

--- a/R/data_prepare.R
+++ b/R/data_prepare.R
@@ -37,7 +37,6 @@ prepare.sf_task <- function( #nolint
   task,
   data_names = c(
     "train_data",
-    "validation_data",
     "test_data",
     "new_data"
     ),

--- a/R/data_prepare.R
+++ b/R/data_prepare.R
@@ -474,7 +474,6 @@ transformation_map_apply <- function(transformation_map, data_to_transform) {
 prepare.cv_task <- function( #nolint
   task,
   data_names = c("train_data",
-    "validation_data",
     "test_data",
     "new_data"
     ),

--- a/R/data_split.R
+++ b/R/data_split.R
@@ -11,9 +11,13 @@
 #'  frac_val. (frac_train + frac_val) doit donc être inférieur à 1. Le seul
 #'  cas où cette condition n'est pas testée est lorsque frac_train = 1.
 #'
-#' @inheritParams generic_task @param ratio `numeric(1)` \cr Ratio of data
-#' used for training. @param resampling `character(1)` \cr Either "holdout" or
-#' "cross_validation" @describeIn split_data
+#' @inheritParams generic_task
+#' @param ratio `numeric(1)` \cr Ratio of data
+#' used for training.
+#' @param resampling `character(1)` \cr Either "holdout" or
+#' "cross_validation"
+#'
+#' @describeIn split_data
 #'
 #' @return `[sf_task]` \cr L'objet \code{task} donné en entrée auquel les
 #' champs "train_data", et "test_data" ont été ajoutés (ou écrasés), chacun

--- a/R/data_split.R
+++ b/R/data_split.R
@@ -23,7 +23,7 @@
 split_data.sf_task <- function(
   task,
   ratio = 2 / 3,
-  resampling_strategy="holdout",
+  resampling_strategy = "holdout",
   ...
 ) {
 

--- a/R/data_split.R
+++ b/R/data_split.R
@@ -1,34 +1,29 @@
-#' Scission des données en échantillon d'entraînement, de validation et de
-#' test.
+
+#' Scission des données en échantillon d'entraînement et de test.
 #'
-#' Scinde les données historiques en échantillon d'entraînement, de validation
-#' et de test, selon les proportions souhaitées. S'assure que deux
-#' établissements de la même entreprise ne soient pas à la fois dans deux
-#' échantillons différents pour éviter la fuite d'information d'un échantillon
-#' vers l'autre.
-#'
-#'  La fraction de l'échantillon de test est calculée par 1 - frac_train -
-#'  frac_val. (frac_train + frac_val) doit donc être inférieur à 1. Le seul
-#'  cas où cette condition n'est pas testée est lorsque frac_train = 1.
+#' Scinde les données historiques en échantillon d'entraînement et de test,
+#' selon le ratio souhaité. S'assure que deux établissements de la
+#' même entreprise ne soient pas à la fois dans deux échantillons différents
+#' pour éviter la fuite d'information d'un échantillon vers l'autre.
 #'
 #' @inheritParams generic_task
 #' @param ratio `numeric(1)` \cr Ratio of data
 #' used for training.
-#' @param resampling `character(1)` \cr Either "holdout" or
-#' "cross_validation"
+#' @param resampling_strategy `character(1)` \cr Either "holdout"
+#' or "cross_validation"
 #'
 #' @describeIn split_data
 #'
 #' @return `[sf_task]` \cr L'objet \code{task} donné en entrée auquel les
 #' champs "train_data", et "test_data" ont été ajoutés (ou écrasés), chacun
 #' contenant un data.frame() avec les colonnes de `task[["hist_data"]]` et un
-#' sous-ensemble (possiblement vide) de ces lignes.
+#' sous-ensemble (possiblement vide) de ses lignes.
 #'
 #' @export
 split_data.sf_task <- function(
   task,
   ratio = 2 / 3,
-  resampling_strategy ="holdout",
+  resampling_strategy="holdout",
   ...
 ) {
 

--- a/R/data_split.R
+++ b/R/data_split.R
@@ -7,30 +7,26 @@
 #' échantillons différents pour éviter la fuite d'information d'un échantillon
 #' vers l'autre.
 #'
-#'  La fraction de l'échantillon de test est calculée par
-#'  1 - frac_train - frac_val. (frac_train + frac_val) doit donc être inférieur
-#'  à 1. Le seul cas où cette condition n'est pas testée est lorsque frac_train
-#'  = 1.
+#'  La fraction de l'échantillon de test est calculée par 1 - frac_train -
+#'  frac_val. (frac_train + frac_val) doit donc être inférieur à 1. Le seul
+#'  cas où cette condition n'est pas testée est lorsque frac_train = 1.
 #'
-#' @inheritParams generic_task
-#' @param ratio `numeric(1)` \cr Ratio of data used for training.
-#' @param resampling `character(1)` \cr Either "holdout" or "cross_validation"
-#' @describeIn split_data
+#' @inheritParams generic_task @param ratio `numeric(1)` \cr Ratio of data
+#' used for training. @param resampling `character(1)` \cr Either "holdout" or
+#' "cross_validation" @describeIn split_data
 #'
-#' @return `[sf_task]` \cr
-#'   L'objet \code{task} donné en entrée auquel les champs "train_data",
-#'   "validation_data" et "test_data" ont été
-#'   ajoutés (ou écrasés), chacun contenant un data.frame() avec les colonnes
-#'   de `task[["hist_data"]]` et un sous-ensemble (possiblement vide) de ces
-#'   lignes.
+#' @return `[sf_task]` \cr L'objet \code{task} donné en entrée auquel les
+#' champs "train_data", et "test_data" ont été ajoutés (ou écrasés), chacun
+#' contenant un data.frame() avec les colonnes de `task[["hist_data"]]` et un
+#' sous-ensemble (possiblement vide) de ces lignes.
 #'
 #' @export
 split_data.sf_task <- function(
   task,
   ratio = 2 / 3,
-  resampling_strategy = "holdout",
+  resampling_strategy ="holdout",
   ...
-  ) {
+) {
 
   set_verbose_level(task)
 

--- a/R/data_split.R
+++ b/R/data_split.R
@@ -50,7 +50,7 @@ split_data.sf_task <- function(
   mlr3_data[[task[["target"]]]] <- as.factor(mlr3_data[[task[["target"]]]])
 
   if (!c("siren") %in% names(mlr3_data)) {
-    mlr3_data["siren"] <- substr(mlr3_data["siret"], 1, 9)
+    mlr3_data$siren <- substr(mlr3_data$siret, 1, 9)
   }
 
   mlr3task <- mlr3::TaskClassif$new(

--- a/R/model_evaluation.R
+++ b/R/model_evaluation.R
@@ -29,7 +29,7 @@
 evaluate <- function(
   ...,
   eval_function =  NULL,
-  data_name = "validation_data",
+  data_name = "test_data",
   plot = TRUE,
   prediction_names = NULL,
   target_names = "outcome",
@@ -105,7 +105,7 @@ evaluate <- function(
 #'
 #' @param ... `sf_tasks | cv_tasks` \cr Tasks to consolidate
 #' @param data_name `character()` \cr Name of the type of data to consolidate
-#' ("train_data", "validation_data", "test_data")
+#' ("train_data", "test_data")
 #'
 consolidate <- function(..., data_name) {
   postfix <- ".cv"

--- a/R/model_optimize.R
+++ b/R/model_optimize.R
@@ -63,10 +63,10 @@ optimize_hyperparameters.sf_task <- function( #nolint
           parameters = as.list(x),
           fields = fields
         )
-        new_task <- predict(new_task, data_names = c("validation_data"))
+        new_task <- predict(new_task, data_names = c("test_data"))
         new_task <- evaluate(
           new_task,
-          data_name = c("validation_data"),
+          data_name = c("test_data"),
           plot = FALSE
         )
         # TODO: Bayesian optimization criteria should be more flexible

--- a/R/model_predict.R
+++ b/R/model_predict.R
@@ -18,7 +18,6 @@ predict.sf_task <- function(
   data_names = c(
     "new_data",
     "train_data",
-    "validation_data",
     "test_data"
     ),
   predict_fun = predict_model,
@@ -82,7 +81,6 @@ predict.cv_task <- function(
   data_names = c(
     "new_data",
     "train_data",
-    "validation_data",
     "test_data"
     ),
   predict_fun = predict_model,

--- a/R/model_train.R
+++ b/R/model_train.R
@@ -131,7 +131,7 @@ train.cv_task  <- function(
 #'
 #' @param train_data `data.frame` \cr données d'entraînement, sous la forme
 #'   d'un H2OFrame
-#' @param validation_data `H2OFrame` \cr Données d'évaluation, sous la forme
+#' @param test_data `H2OFrame` \cr Données d'évaluation, sous la forme
 #'   d'un H2OFrame
 #' @param outcome `character(1)` \cr Nom de la variable qui sert de cible
 #'   d'apprentissage
@@ -145,7 +145,7 @@ train.cv_task  <- function(
 train_xgboost <- function(
   train_data,
   outcome,
-  validation_data = NULL,
+  test_data = NULL,
   learn_rate = 0.1,
   max_depth = 4,
   ntrees = 60,
@@ -177,7 +177,7 @@ train_xgboost <- function(
 #'
 #' @param train_data `data.frame` \cr données d'entraînement, sous la forme
 #'   d'un H2OFrame
-#' @param validation_data `H2OFrame` \cr Données d'évaluation, sous la forme
+#' @param test_data `data.frame` \cr Données d'évaluation, sous la forme
 #'   d'un H2OFrame
 #' @param outcome `character(1)` \cr Nom de la variable qui sert de cible
 #'   d'apprentissage
@@ -189,7 +189,7 @@ train_xgboost <- function(
 train_linear <- function(
   train_data,
   outcome,
-  validation_data = NULL,
+  test_data = NULL,
   parameters,
   seed = 123
   ) {

--- a/R/testing.R
+++ b/R/testing.R
@@ -54,7 +54,7 @@ get_test_task <- function(
   if (stage == "load") {
     return(task)
   }
-  task  <- split_data(task)
+  task  <- split_data(task, ratio = 2 / 3, resampling_strategy = "holdout")
   if (stage == "split") {
     return(task)
   }

--- a/R/testing.R
+++ b/R/testing.R
@@ -62,7 +62,6 @@ get_test_task <- function(
   task[["new_data"]]  <- task[["hist_data"]]
   task[["prepared_train_data"]]  <- task[["train_data"]]
   task[["prepared_test_data"]]  <- task[["test_data"]]
-  task[["prepared_validation_data"]]  <- task[["validation_data"]]
   task[["outcome_field"]] <- "target"
 
   # stage == "prepare"

--- a/man/consolidate.Rd
+++ b/man/consolidate.Rd
@@ -10,7 +10,7 @@ consolidate(..., data_name)
 \item{...}{\code{sf_tasks | cv_tasks} \cr Tasks to consolidate}
 
 \item{data_name}{\code{character()} \cr Name of the type of data to consolidate
-("train_data", "validation_data", "test_data")}
+("train_data", "test_data")}
 }
 \description{
 Consolidate several tasks into a frame for evaluation

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -7,7 +7,7 @@
 evaluate(
   ...,
   eval_function = NULL,
-  data_name = "validation_data",
+  data_name = "test_data",
   plot = TRUE,
   prediction_names = NULL,
   target_names = "outcome",

--- a/man/predict.cv_task.Rd
+++ b/man/predict.cv_task.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{predict}{cv_task}(
   object,
-  data_names = c("new_data", "train_data", "validation_data", "test_data"),
+  data_names = c("new_data", "train_data", "test_data"),
   predict_fun = predict_model,
   ...
 )

--- a/man/predict.sf_task.Rd
+++ b/man/predict.sf_task.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{predict}{sf_task}(
   object,
-  data_names = c("new_data", "train_data", "validation_data", "test_data"),
+  data_names = c("new_data", "train_data", "test_data"),
   predict_fun = predict_model,
   ...
 )

--- a/man/prepare.cv_task.Rd
+++ b/man/prepare.cv_task.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{prepare}{cv_task}(
   task,
-  data_names = c("train_data", "validation_data", "test_data", "new_data"),
+  data_names = c("train_data", "test_data", "new_data"),
   preparation_map_function = create_fte_map,
   preparation_map_options = list(outcome_field = outcome_field, target_encode_fields =
     c("code_ape_niveau2", "code_ape_niveau3")),

--- a/man/prepare.sf_task.Rd
+++ b/man/prepare.sf_task.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{prepare}{sf_task}(
   task,
-  data_names = c("train_data", "validation_data", "test_data", "new_data"),
+  data_names = c("train_data", "test_data", "new_data"),
   training_fields = get_fields(training = TRUE),
   outcome_field = "outcome",
   preparation_map_function = create_fte_map,

--- a/man/split_data.Rd
+++ b/man/split_data.Rd
@@ -13,19 +13,19 @@ split_data(task, ...)
 \arguments{
 \item{task}{\verb{[sf_task]} \cr Objet s3 de type sf_task}
 
-\item{ratio}{\code{numeric(1)} \cr Ratio of data used for training.}
+\item{ratio}{\code{numeric(1)} \cr Ratio of data
+used for training.}
 
 \item{...}{Not used}
 
-\item{resampling}{\code{character(1)} \cr Either "holdout" or "cross_validation"}
+\item{resampling}{\code{character(1)} \cr Either "holdout" or
+"cross_validation"}
 }
 \value{
-\verb{[sf_task]} \cr
-L'objet \code{task} donné en entrée auquel les champs "train_data",
-"validation_data" et "test_data" ont été
-ajoutés (ou écrasés), chacun contenant un data.frame() avec les colonnes
-de \code{task[["hist_data"]]} et un sous-ensemble (possiblement vide) de ces
-lignes.
+\verb{[sf_task]} \cr L'objet \code{task} donné en entrée auquel les
+champs "train_data", et "test_data" ont été ajoutés (ou écrasés), chacun
+contenant un data.frame() avec les colonnes de \code{task[["hist_data"]]} et un
+sous-ensemble (possiblement vide) de ces lignes.
 }
 \description{
 Scinde les données historiques en échantillon d'entraînement, de validation
@@ -35,13 +35,12 @@ et de test, selon les proportions souhaitées. S'assure que deux
 vers l'autre.
 }
 \details{
-La fraction de l'échantillon de test est calculée par
-1 - frac_train - frac_val. (frac_train + frac_val) doit donc être inférieur
-à 1. Le seul cas où cette condition n'est pas testée est lorsque frac_train
-= 1.
+La fraction de l'échantillon de test est calculée par 1 - frac_train -
+frac_val. (frac_train + frac_val) doit donc être inférieur à 1. Le seul
+cas où cette condition n'est pas testée est lorsque frac_train = 1.
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{sf_task}:
+\item \code{sf_task}: 
 }}
 

--- a/man/split_data.Rd
+++ b/man/split_data.Rd
@@ -42,6 +42,6 @@ La fraction de l'échantillon de test est calculée par
 }
 \section{Methods (by class)}{
 \itemize{
-\item \code{sf_task}: 
+\item \code{sf_task}:
 }}
 

--- a/man/split_data.Rd
+++ b/man/split_data.Rd
@@ -3,8 +3,7 @@
 \name{split_data.sf_task}
 \alias{split_data.sf_task}
 \alias{split_data}
-\title{Scission des données en échantillon d'entraînement, de validation et de
-test.}
+\title{Scission des données en échantillon d'entraînement et de test.}
 \usage{
 \method{split_data}{sf_task}(task, ratio = 2/3, resampling_strategy = "holdout", ...)
 
@@ -16,28 +15,22 @@ split_data(task, ...)
 \item{ratio}{\code{numeric(1)} \cr Ratio of data
 used for training.}
 
-\item{...}{Not used}
+\item{resampling_strategy}{\code{character(1)} \cr Either "holdout"
+or "cross_validation"}
 
-\item{resampling}{\code{character(1)} \cr Either "holdout" or
-"cross_validation"}
+\item{...}{Not used}
 }
 \value{
 \verb{[sf_task]} \cr L'objet \code{task} donné en entrée auquel les
 champs "train_data", et "test_data" ont été ajoutés (ou écrasés), chacun
 contenant un data.frame() avec les colonnes de \code{task[["hist_data"]]} et un
-sous-ensemble (possiblement vide) de ces lignes.
+sous-ensemble (possiblement vide) de ses lignes.
 }
 \description{
-Scinde les données historiques en échantillon d'entraînement, de validation
-et de test, selon les proportions souhaitées. S'assure que deux
-établissements de la même entreprise ne soient pas à la fois dans deux
-échantillons différents pour éviter la fuite d'information d'un échantillon
-vers l'autre.
-}
-\details{
-La fraction de l'échantillon de test est calculée par 1 - frac_train -
-frac_val. (frac_train + frac_val) doit donc être inférieur à 1. Le seul
-cas où cette condition n'est pas testée est lorsque frac_train = 1.
+Scinde les données historiques en échantillon d'entraînement et de test,
+selon le ratio souhaité. S'assure que deux établissements de la
+même entreprise ne soient pas à la fois dans deux échantillons différents
+pour éviter la fuite d'information d'un échantillon vers l'autre.
 }
 \section{Methods (by class)}{
 \itemize{

--- a/man/train_linear.Rd
+++ b/man/train_linear.Rd
@@ -4,13 +4,7 @@
 \alias{train_linear}
 \title{Train a linear model}
 \usage{
-train_linear(
-  train_data,
-  outcome,
-  validation_data = NULL,
-  parameters,
-  seed = 123
-)
+train_linear(train_data, outcome, test_data = NULL, parameters, seed = 123)
 }
 \arguments{
 \item{train_data}{\code{data.frame} \cr données d'entraînement, sous la forme
@@ -19,7 +13,7 @@ d'un H2OFrame}
 \item{outcome}{\code{character(1)} \cr Nom de la variable qui sert de cible
 d'apprentissage}
 
-\item{validation_data}{\code{H2OFrame} \cr Données d'évaluation, sous la forme
+\item{test_data}{\code{data.frame} \cr Données d'évaluation, sous la forme
 d'un H2OFrame}
 
 \item{parameters}{\code{list()} \cr Paramètres de la régression logistique.}

--- a/man/train_xgboost.Rd
+++ b/man/train_xgboost.Rd
@@ -7,7 +7,7 @@
 train_xgboost(
   train_data,
   outcome,
-  validation_data = NULL,
+  test_data = NULL,
   learn_rate = 0.1,
   max_depth = 4,
   ntrees = 60,
@@ -22,7 +22,7 @@ d'un H2OFrame}
 \item{outcome}{\code{character(1)} \cr Nom de la variable qui sert de cible
 d'apprentissage}
 
-\item{validation_data}{\code{H2OFrame} \cr Données d'évaluation, sous la forme
+\item{test_data}{\code{H2OFrame} \cr Données d'évaluation, sous la forme
 d'un H2OFrame}
 
 \item{seed}{\code{integer(1)} \cr Graine aléatoire pour que les opérations

--- a/tests/testthat/test-data_split.R
+++ b/tests/testthat/test-data_split.R
@@ -136,5 +136,3 @@ test_that(
     task[["tracker"]] <- NULL
   }
 )
-
-# TODO: remove here package from dependencies.

--- a/tests/testthat/test-model_explain.R
+++ b/tests/testthat/test-model_explain.R
@@ -31,7 +31,7 @@
 #   without_aggregation <- explain(
 #     test_task,
 #     type = "local",
-#     data_to_explain = test_task[["validation_data"]]
+#     data_to_explain = test_task[["test_data"]]
 #     )
 #
 #   with_aggregation <- explain(
@@ -39,7 +39,7 @@
 #     type = "local",
 #     aggregation_matrix = test_aggregation_matrix,
 #     group_name = "group",
-#     data_to_explain = test_task[["validation_data"]]
+#     data_to_explain = test_task[["test_data"]]
 #     )
 # })
 #
@@ -47,7 +47,7 @@
 #   without_aggregation <- explain(
 #     test_task,
 #     type = "local",
-#     data_to_explain = test_task[["validation_data"]]
+#     data_to_explain = test_task[["test_data"]]
 #     )
 #   plot_waterfall(without_aggregation[7,])
 #

--- a/tests/testthat/test-model_predict.R
+++ b/tests/testthat/test-model_predict.R
@@ -9,10 +9,11 @@ test_that("predict.sf_task works as expected", {
   test_task[["model"]] <- list()
   predicted_task <- predict(
     test_task,
-    data_names = "validation_data",
+    data_names = "test_data",
     predict_fun = test_predict_fun
   )
-  expect_equal(predicted_task[["validation_data"]]$score, rep(1, 5))
+  pred_data <- predicted_task[["test_data"]]
+  expect_equal(pred_data$score, rep(1, nrow(pred_data)))
 })
 
 test_that("predict.cv_task works as expected", {
@@ -26,11 +27,9 @@ test_that("predict.cv_task works as expected", {
   )
   predicted_task <- predict(
     test_task,
-    data_names = "validation_data",
+    data_names = "test_data",
     predict_fun = test_predict_fun
   )
-  expect_equal(
-    predicted_task[["cross_validation"]][[3]][["validation_data"]]$score,
-    rep(1, 5)
-  )
+  pred_data <- predicted_task[["cross_validation"]][[3]][["test_data"]]
+  expect_equal(pred_data$score, rep(1, nrow(pred_data)))
 })


### PR DESCRIPTION
- Changement des fonctions et tests qui reposaient sur "validation_data" pour fonctionner avec "test_data". 
- Retrait de la dépendance au package "here". 
- Mise-à-jour de la documentation. 