### PR TITLE
tests(mlr3): Ajout de tests avec de la validation croisée.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,6 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Imports:
-    MLsegmentr,
     assertthat,
     dplyr,
     fte,
@@ -43,7 +42,6 @@ Suggests:
 Remotes:
     AppliedDataSciencePartners/xgboostExplainer,
     mlr-org/mlr3pipelines,
-    signaux-faibles/MLsegmentr,
     signaux-faibles/fte
 RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/test-data_prepare.R
+++ b/tests/testthat/test-data_prepare.R
@@ -50,11 +50,21 @@ create_prepared_task <- function(test_task,
   return(prepared_task)
 }
 
-
 test_that("no error is thrown with a valid 'processing_pipeline'", {
   expect_error(
     get_test_task(
       stage = "prepare",
+      processing_pipeline = mlr3pipelines::PipeOpNOP$new()
+    ),
+  NA
+  )
+})
+
+test_that("no error is thrown with a valid 'processing_pipeline' with cv", {
+  expect_error(
+    get_test_task(
+      stage = "prepare",
+      resampling_strategy = "cv",
       processing_pipeline = mlr3pipelines::PipeOpNOP$new()
     ),
   NA
@@ -66,6 +76,7 @@ fake_pipe <- mlr3pipelines::PipeOpScale$new(
 )
 fake_pipe <- mlr3pipelines::as_graph(fake_pipe)
 
+# TEMP: will be deleted
 test_that("'processing_pipeline' is correctly applied", {
   prepared_task <- get_test_task(
     stage = "prepare",
@@ -95,9 +106,27 @@ test_that("'processing_pipeline' is correctly applied", {
   test_mean_sd(sd, 0.46, "test")
 })
 
+
 test_that("processing pipeline is stored in 'mlr3pipeline' property", {
   test_mlr3pipeline_prop <- function(pipe) {
     prep_task <- get_test_task(stage = "prepare", processing_pipeline = pipe)
+    expect_true("mlr3pipeline" %in% names(prep_task))
+    expect_true(inherits(prep_task[["mlr3pipeline"]], "PipeOp") ||
+      inherits(prep_task[["mlr3pipeline"]], "Graph"))
+  }
+  test_mlr3pipeline_prop(mlr3pipelines::PipeOpNOP$new())
+  test_mlr3pipeline_prop(
+    mlr3pipelines::as_graph(mlr3pipelines::PipeOpNOP$new())
+  )
+})
+
+test_that("processing pipeline is stored in 'mlr3pipeline' property with cv", {
+  test_mlr3pipeline_prop <- function(pipe) {
+    prep_task <- get_test_task(
+      stage = "prepare",
+      resampling_strategy = "cv",
+      processing_pipeline = pipe
+    )
     expect_true("mlr3pipeline" %in% names(prep_task))
     expect_true(inherits(prep_task[["mlr3pipeline"]], "PipeOp") ||
       inherits(prep_task[["mlr3pipeline"]], "Graph"))

--- a/tests/testthat/test-data_split.R
+++ b/tests/testthat/test-data_split.R
@@ -37,8 +37,6 @@ test_that(
     )
 })
 
-
-
 test_that("works with 'cv' resampling strategy,", {
     expect_error(split_data(test_task, resampling_strategy = "cv"), NA)
 })

--- a/tests/testthat/test-model_evaluation.R
+++ b/tests/testthat/test-model_evaluation.R
@@ -12,6 +12,18 @@ test_that("evaluate works as expected on sf_tasks",  {
   expect_equal(benchmark_result$classif.acc, 1 / 3)
 })
 
+test_that("evaluate works as expected on sf_tasks with cv",  {
+  requireNamespace("mlr3measures")
+  trained_task <- get_test_task(
+    stage = "train",
+    resampling_strategy = "cv",
+    learner = mlr3::LearnerClassifFeatureless$new()
+  )
+  benchmark_result <- evaluate(trained_task, measures = msr("classif.acc"))
+  expect_is(benchmark_result, "data.table")
+  expect_true("classif.acc" %in% names(benchmark_result))
+  expect_equal(benchmark_result$classif.acc, 0.1)
+})
 
 test_that("evaluate works as expected on two sf_tasks",  {
   requireNamespace("mlr3measures")
@@ -32,6 +44,29 @@ test_that("evaluate works as expected on two sf_tasks",  {
   expect_is(benchmark_result, "data.table")
   expect_true("classif.acc" %in% names(benchmark_result))
   expect_equal(benchmark_result$classif.acc, c(1 / 3, 1 / 3))
+})
+
+
+test_that("evaluate works as expected on two sf_tasks with mixed cv and holdout",  {
+  requireNamespace("mlr3measures")
+  trained_task <- get_test_task(
+    stage = "train",
+    resampling_strategy = "cv",
+    learner = mlr3::LearnerClassifFeatureless$new()
+  )
+  other_task <- get_test_task(
+    stage = "train",
+    learner = mlr3::LearnerClassifFeatureless$new()
+  )
+
+  benchmark_result <- evaluate(
+    other_task,
+    trained_task,
+    measures = msr("classif.acc")
+  )
+  expect_is(benchmark_result, "data.table")
+  expect_true("classif.acc" %in% names(benchmark_result))
+  expect_equal(benchmark_result$classif.acc, c(1 / 3, 1 / 10))
 })
 
 

--- a/tests/testthat/test-model_predict.R
+++ b/tests/testthat/test-model_predict.R
@@ -25,6 +25,26 @@ test_that("predict works as expected with mlr3", {
    trained_task <- predict(trained_task, data_names = "test_data")
    expect_true("prediction_test" %in% names(trained_task))
    expect_is(trained_task$prediction_test, "PredictionClassif")
+   expect_equal(
+     trained_task$prediction_test %>% data.table::as.data.table() %>% nrow(),
+     3
+   )
+})
+
+
+test_that("predict works as expected with mlr3, with cv", {
+   trained_task <- get_test_task(
+     stage = "train",
+     resampling_strategy = "cv",
+     learner = mlr3::LearnerClassifFeatureless$new()
+   )
+   trained_task <- predict(trained_task, data_names = "test_data")
+   expect_true("prediction_test" %in% names(trained_task))
+   expect_is(trained_task$prediction_test, "PredictionClassif")
+   expect_equal(
+     trained_task$prediction_test %>% data.table::as.data.table() %>% nrow(),
+     10
+   )
 })
 
 test_that("predict works as expected with mlr3", {

--- a/tests/testthat/test-model_train.R
+++ b/tests/testthat/test-model_train.R
@@ -42,6 +42,34 @@ test_that("train.sf_task works with learner as expected", {
   )
 })
 
+test_that("train.sf_task works with learner and cv as expected ", {
+  test_task <- get_test_task(resampling_strategy = "cv")
+  test_task[["mlr3pipeline"]] <- mlr3pipelines::po("nop")
+  test_task[["model_parameters"]] <- list()
+  trained_task <- train(
+    task = test_task,
+    outcome = "target",
+    learner = mlr3::lrn("classif.featureless")
+  )
+  expect_equal(
+    c(classif.acc = 0.1),
+    trained_task[["mlr3resampled"]]$aggregate(mlr3::msr("classif.acc")),
+  )
+})
+
+test_that("processing pipeline is stored in 'mlr3pipeline' property", {
+  test_mlr3pipeline_prop <- function(pipe) {
+    prep_task <- get_test_task(stage = "prepare", processing_pipeline = pipe)
+    expect_true("mlr3pipeline" %in% names(prep_task))
+    expect_true(inherits(prep_task[["mlr3pipeline"]], "PipeOp") ||
+      inherits(prep_task[["mlr3pipeline"]], "Graph"))
+  }
+  test_mlr3pipeline_prop(mlr3pipelines::PipeOpNOP$new())
+  test_mlr3pipeline_prop(
+    mlr3pipelines::as_graph(mlr3pipelines::PipeOpNOP$new())
+  )
+})
+
 
 test_that("train.sf_task works with learner as expected", {
   test_task <- get_test_task()


### PR DESCRIPTION
Ajout de tests avec de la validation croisée pour: 
- `prepare`,
- `train`, 
- `predict`,
- `eval`

Retrait de MLsegmentr des dépendances (plus utilisé)