### PR TITLE
fix: CI lancée en double

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push]
 
 name: R-CMD-check
 


### PR DESCRIPTION
Cette PR retire la CI déclenchée pour les "pull request" car elle se lançait en double avec celle des "push"