### PR TITLE
feat: étendre la fonctionnalité de `get_prepared_data` à une tâche sans échanillonnage.

### DIFF
--- a/R/data_prepare.R
+++ b/R/data_prepare.R
@@ -82,7 +82,9 @@ get_default_pipeline <- function() {
 #'
 #' @inheritParams generic_task
 #' @param train_or_test `"train" or "test"` Faut-il récupérer les données
-#' d'entraînement ou de test ?
+#' d'entraînement ou de test ? Ce paramètre n'est pas requis si les données ne
+#' sont pas échantillonnées (alors l'intégralité des données sont utilisées
+#' pour l'entraînement).
 #'
 #' @return `data.frame` données d'entraînement ou de test après la préparation
 #' (l'application de la pipeline mlr3 stockée dans "task"

--- a/R/data_prepare.R
+++ b/R/data_prepare.R
@@ -72,7 +72,7 @@ get_default_pipeline <- function() {
 #' Apply preparation pipeline and inspect prepared data
 #'
 #' Applique la pipeline de préparation sur les données d'entraînement ou de
-#' test.
+#' test (que le premier échantillon en cas de validation croisée).
 #'
 #' L'objet task doit avoir une propriété "mlr3pipeline" de type
 #' `mlr3pipelines::PipeOp` ou `mlr3pipelines::Graph`
@@ -86,19 +86,26 @@ get_default_pipeline <- function() {
 #'
 #' @export
 get_prepared_data <- function(task, train_or_test) {
-  assertthat::assert_that(train_or_test %in% c("train", "test"))
+  assertthat::assert_that(!"mlr3rsmp" %in% names(task) ||
+    train_or_test %in% c("train", "test"))
   assertthat::assert_that(
     "mlr3pipeline" %in% names(task),
     msg = "A pipeline is needed to get prepared data (property: mlr3pipeline)"
   )
-  train_id <- task[["mlr3rsmp"]]$train_set(1)
-  gpo <- mlr3pipelines::as_graph(task[["mlr3pipeline"]])
-  gpo$train(task[["mlr3task"]]$clone()$filter(train_id))
-  pred <- gpo$predict(task[["mlr3task"]])[[1]]
-  if (train_or_test == "test") {
-    test_id <- task[["mlr3rsmp"]]$test_set(1)
-    return(as.data.frame(pred$data(test_id)))
+  if (!"mlr3rsmp" %in% names(task)) {
+    train_ids <- task[["mlr3task"]]$row_ids
+    predict_ids <- train_ids
   } else {
-    return(as.data.frame(pred$data(train_id)))
+    train_ids <- task[["mlr3rsmp"]]$train_set(1)
+    if (train_or_test == "train") {
+      predict_ids <- train_ids
+    } else {
+      predict_ids <- task[["mlr3rsmp"]]$test_set(1)
+    }
   }
+  gpo <- mlr3pipelines::as_graph(task[["mlr3pipeline"]])
+  gpo$train(task[["mlr3task"]]$clone()$filter(train_ids))
+  pred <- gpo$predict(task[["mlr3task"]])[[1]]
+
+  return(as.data.frame(pred$data(predict_ids)))
 }

--- a/R/data_prepare.R
+++ b/R/data_prepare.R
@@ -74,6 +74,9 @@ get_default_pipeline <- function() {
 #' Applique la pipeline de préparation sur les données d'entraînement ou de
 #' test (que le premier échantillon en cas de validation croisée).
 #'
+#' Cette fonction est uniquement prévue pour l'inspection du bon
+#' fonctionnement de la pipeline de préparation.
+#'
 #' L'objet task doit avoir une propriété "mlr3pipeline" de type
 #' `mlr3pipelines::PipeOp` ou `mlr3pipelines::Graph`
 #'

--- a/tests/testthat/test-data_prepare.R
+++ b/tests/testthat/test-data_prepare.R
@@ -164,7 +164,6 @@ create_fte_test_task <- function(processing_pipeline = NULL) {
 }
 
 test_that("fte state works as expected", {
-  testthat::skip_on_ci()
   prep_task <- create_fte_test_task(create_fte_pipeline(c("ab", "cd")))
 
   expect_known_hash(

--- a/tests/testthat/test-data_prepare.R
+++ b/tests/testthat/test-data_prepare.R
@@ -164,6 +164,7 @@ create_fte_test_task <- function(processing_pipeline = NULL) {
 }
 
 test_that("fte state works as expected", {
+  testthat::skip_on_ci()
   prep_task <- create_fte_test_task(create_fte_pipeline(c("ab", "cd")))
 
   expect_known_hash(

--- a/tests/testthat/test-data_prepare.R
+++ b/tests/testthat/test-data_prepare.R
@@ -195,3 +195,12 @@ test_that("preparing twice with different training fields takes effect", {
   )
   check_names(c("outcome", "feature", "ab", "cd"))
 })
+
+test_that("get_prepared_data works with and without resampling", {
+  prep_task <- get_test_task(stage = "prepare")
+  # Remove resampling plan
+  expect_equal(dim(get_prepared_data(prep_task, train_or_test = "train")), c(7, 2))
+  expect_equal(dim(get_prepared_data(prep_task, train_or_test = "test")), c(3, 2))
+  prep_task[["mlr3rsmp"]] <- NULL
+  expect_equal(dim(get_prepared_data(prep_task)), c(10, 2))
+})


### PR DESCRIPTION
`get_prepared_data` permet d'inspecter les données préparées (ou une partie des données en cas de validation croisée), notamment pour s'assurer du bon fonctionnement de la préparation. Cette fonction ne fonctionnait que pour des données échantillonnées (après usage de `split_data`) mais pas quand l'intégralité des données est utilisée pour l'entraînement. 

Cette PR rajoute cette fonctionnalité, et en particulier:
* Le paramètre `test_or_train` ne s'applique pas s'il n'y a pas eu d'échantillonnage
* La documentation a été complétée en conséquence
* Des tests unitaires ont été ajoutés pour tester ce cas précis et le cas avec échantillonnage. 